### PR TITLE
Potential fix for code scanning alert no. 2: Stored cross-site scripting

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -1,6 +1,7 @@
 import express, { Express, Request, Response } from "express";
 import dotenv from "dotenv";
 import fs from "fs";
+import escape from "escape-html";
 
 dotenv.config();
 
@@ -54,7 +55,7 @@ app.get("/", (req: Request, res: Response) => {
       ${files.map(file => `
         <li>
           <i class="fas fa-fw fa-file"></i>
-          <a href="${file}">${file}</a>
+          <a href="${escape(file)}">${escape(file)}</a>
         </li>
       `).join('')}
     </ul>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "cross-env": "^7.0.3",
         "dotenv": "^16.4.7",
+        "escape-html": "^1.0.3",
         "eslint": "^9.21.0",
         "express": "^4.21.2",
         "globals": "^16.0.0",
@@ -19,6 +20,7 @@
       "devDependencies": {
         "@eslint/js": "^9.21.0",
         "@jest/globals": "^29.7.0",
+        "@types/escape-html": "^1.0.4",
         "@types/express": "^5.0.0",
         "@types/jest": "^29.5.14",
         "@types/node": "^22.13.9",
@@ -1865,6 +1867,13 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
       "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/escape-html": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/escape-html/-/escape-html-1.0.4.tgz",
+      "integrity": "sha512-qZ72SFTgUAZ5a7Tj6kf2SHLetiH5S6f8G5frB2SPQ3EyF02kxdyBFf4Tz4banE3xCgGnKgWLt//a6VuYHKYJTg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -2,15 +2,16 @@
   "dependencies": {
     "cross-env": "^7.0.3",
     "dotenv": "^16.4.7",
+    "escape-html": "^1.0.3",
     "eslint": "^9.21.0",
     "express": "^4.21.2",
     "globals": "^16.0.0",
-    "supertest": "^7.0.0",
-    "escape-html": "^1.0.3"
+    "supertest": "^7.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",
     "@jest/globals": "^29.7.0",
+    "@types/escape-html": "^1.0.4",
     "@types/express": "^5.0.0",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.13.9",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "eslint": "^9.21.0",
     "express": "^4.21.2",
     "globals": "^16.0.0",
-    "supertest": "^7.0.0"
+    "supertest": "^7.0.0",
+    "escape-html": "^1.0.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",


### PR DESCRIPTION
Potential fix for [https://github.com/blastoffwaters/static-content-server/security/code-scanning/2](https://github.com/blastoffwaters/static-content-server/security/code-scanning/2)

To fix the stored cross-site scripting vulnerability, we need to sanitize the filenames before embedding them into the HTML response. The best way to do this is by using a library like `escape-html` to escape any potentially dangerous characters in the filenames.

- We will import the `escape-html` library.
- We will use the `escape` function from the `escape-html` library to sanitize the filenames before embedding them into the HTML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
